### PR TITLE
add retry mechanism for pod listing when recovering previous Kubernetes workers

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -441,11 +441,14 @@ public class KubernetesConfigOptions {
                                             code("FlinkKubeClient#checkAndUpdateConfigMap"))
                                     .build());
 
-    public static final ConfigOption<Duration> KUBERNETES_TRANSACTIONAL_OPERATION_RETRY_INTERVAL =
-            key("kubernetes.transactional-operation.retry-interval")
-                    .durationType()
-                    .defaultValue(Duration.ofMillis(3000))
-                    .withDescription("Interval between each retries of kubernetes transactional operation.");
+    public static final ConfigOption<Duration>
+            KUBERNETES_TRANSACTIONAL_OPERATION_INIT_RETRY_INTERVAL =
+                    key("kubernetes.transactional-operation.retry-interval-initial")
+                            .durationType()
+                            .defaultValue(Duration.ofMillis(3000))
+                            .withDescription(
+                                    "The initial interval between each retries of kubernetes transactional operation. The"
+                                            + " interval of the following retries will be 1.5 times of the previous retry interval.");
 
     public static final ConfigOption<String> JOB_MANAGER_POD_TEMPLATE;
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -439,6 +440,12 @@ public class KubernetesConfigOptions {
                                                     + "client gives up. For example, %s.",
                                             code("FlinkKubeClient#checkAndUpdateConfigMap"))
                                     .build());
+
+    public static final ConfigOption<Duration> KUBERNETES_TRANSACTIONAL_OPERATION_RETRY_INTERVAL =
+            key("kubernetes.transactional-operation.retry-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(3000))
+                    .withDescription("Interval between each retries of kubernetes transactional operation.");
 
     public static final ConfigOption<String> JOB_MANAGER_POD_TEMPLATE;
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -191,21 +191,27 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public CompletableFuture<List<KubernetesPod>> getPodsWithLabels(Map<String, String> labels) {
-        return  CompletableFuture.supplyAsync(() -> {
-            final List<Pod> podList =
-                    this.internalClient
-                            .pods()
-                            .withLabels(labels)
-                            .list(new ListOptionsBuilder()
-                                    .withResourceVersion(KUBERNETES_ZERO_RESOURCE_VERSION)
-                                    .build())
-                            .getItems();
-            if (podList == null || podList.isEmpty()) {
-                return Collections.emptyList();
-            }else {
-                return podList.stream().map(KubernetesPod::new).collect(Collectors.toList());
-            }
-        }, kubeClientExecutorService);
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    final List<Pod> podList =
+                            this.internalClient
+                                    .pods()
+                                    .withLabels(labels)
+                                    .list(
+                                            new ListOptionsBuilder()
+                                                    .withResourceVersion(
+                                                            KUBERNETES_ZERO_RESOURCE_VERSION)
+                                                    .build())
+                                    .getItems();
+                    if (podList == null || podList.isEmpty()) {
+                        return Collections.emptyList();
+                    } else {
+                        return podList.stream()
+                                .map(KubernetesPod::new)
+                                .collect(Collectors.toList());
+                    }
+                },
+                kubeClientExecutorService);
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -96,7 +96,7 @@ public interface FlinkKubeClient extends AutoCloseable {
      * @param labels labels to filter the pods
      * @return pod list
      */
-    List<KubernetesPod> getPodsWithLabels(Map<String, String> labels);
+    CompletableFuture<List<KubernetesPod>> getPodsWithLabels(Map<String, String> labels);
 
     /**
      * Watch the pods selected by labels and do the {@link WatchCallbackHandler}.

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -281,7 +281,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     }
 
     @Test
-    void testGetPodsWithLabels() {
+    void testGetPodsWithLabels() throws ExecutionException, InterruptedException {
         final String podName = "pod-with-labels";
         final Pod pod =
                 new PodBuilder()
@@ -293,7 +293,8 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                         .endSpec()
                         .build();
         this.kubeClient.pods().inNamespace(NAMESPACE).create(pod);
-        List<KubernetesPod> kubernetesPods = this.flinkKubeClient.getPodsWithLabels(TESTING_LABELS);
+        List<KubernetesPod> kubernetesPods = this.flinkKubeClient.getPodsWithLabels(TESTING_LABELS)
+                .get();
         assertThat(kubernetesPods)
                 .satisfiesExactly(
                         kubernetesPod -> assertThat(kubernetesPod.getName()).isEqualTo(podName));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -293,8 +293,8 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                         .endSpec()
                         .build();
         this.kubeClient.pods().inNamespace(NAMESPACE).create(pod);
-        List<KubernetesPod> kubernetesPods = this.flinkKubeClient.getPodsWithLabels(TESTING_LABELS)
-                .get();
+        List<KubernetesPod> kubernetesPods =
+                this.flinkKubeClient.getPodsWithLabels(TESTING_LABELS).get();
         assertThat(kubernetesPods)
                 .satisfiesExactly(
                         kubernetesPod -> assertThat(kubernetesPod.getName()).isEqualTo(podName));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -95,8 +95,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                             KubernetesLeaderElector.LeaderCallbackHandler,
                             KubernetesLeaderElector>
                     createLeaderElectorFunction,
-            Function<String, KubernetesConfigMapSharedWatcher>
-                    createConfigMapSharedWatcherFunction,
+            Function<String, KubernetesConfigMapSharedWatcher> createConfigMapSharedWatcherFunction,
             int errorTimesForPodListing) {
 
         this.createTaskManagerPodFunction = createTaskManagerPodFunction;
@@ -149,9 +148,9 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
 
     @Override
     public CompletableFuture<List<KubernetesPod>> getPodsWithLabels(Map<String, String> labels) {
-        if(errorTimesForPodListing > 0){
+        if (errorTimesForPodListing > 0) {
             CompletableFuture<List<KubernetesPod>> future = new CompletableFuture<>();
-            errorTimesForPodListing --;
+            errorTimesForPodListing--;
             future.completeExceptionally(new Exception("too many requests"));
             return future;
         }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -72,6 +72,8 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     private final Function<String, KubernetesConfigMapSharedWatcher>
             createConfigMapSharedWatcherFunction;
 
+    private int errorTimesForPodListing;
+
     private TestingFlinkKubeClient(
             Function<KubernetesPod, CompletableFuture<Void>> createTaskManagerPodFunction,
             Function<String, CompletableFuture<Void>> stopPodFunction,
@@ -94,7 +96,8 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                             KubernetesLeaderElector>
                     createLeaderElectorFunction,
             Function<String, KubernetesConfigMapSharedWatcher>
-                    createConfigMapSharedWatcherFunction) {
+                    createConfigMapSharedWatcherFunction,
+            int errorTimesForPodListing) {
 
         this.createTaskManagerPodFunction = createTaskManagerPodFunction;
         this.stopPodFunction = stopPodFunction;
@@ -111,6 +114,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
 
         this.createLeaderElectorFunction = createLeaderElectorFunction;
         this.createConfigMapSharedWatcherFunction = createConfigMapSharedWatcherFunction;
+        this.errorTimesForPodListing = errorTimesForPodListing;
     }
 
     @Override
@@ -144,8 +148,14 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public List<KubernetesPod> getPodsWithLabels(Map<String, String> labels) {
-        return getPodsWithLabelsFunction.apply(labels);
+    public CompletableFuture<List<KubernetesPod>> getPodsWithLabels(Map<String, String> labels) {
+        if(errorTimesForPodListing > 0){
+            CompletableFuture<List<KubernetesPod>> future = new CompletableFuture<>();
+            errorTimesForPodListing --;
+            future.completeExceptionally(new Exception("too many requests"));
+            return future;
+        }
+        return CompletableFuture.completedFuture(getPodsWithLabelsFunction.apply(labels));
     }
 
     @Override
@@ -245,6 +255,8 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         private Function<String, KubernetesConfigMapSharedWatcher>
                 createConfigMapSharedWatcherFunction = TestingKubernetesConfigMapSharedWatcher::new;
 
+        private int errorTimesForPodListing;
+
         private Builder() {}
 
         public Builder setCreateTaskManagerPodFunction(
@@ -334,6 +346,11 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
             return this;
         }
 
+        public Builder setErrorTimesForPodListing(int numOfErrorTimes) {
+            this.errorTimesForPodListing = numOfErrorTimes;
+            return this;
+        }
+
         public TestingFlinkKubeClient build() {
             return new TestingFlinkKubeClient(
                     createTaskManagerPodFunction,
@@ -347,7 +364,8 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                     deleteConfigMapFunction,
                     closeConsumer,
                     createLeaderElectorFunction,
-                    createConfigMapSharedWatcherFunction);
+                    createConfigMapSharedWatcherFunction,
+                    errorTimesForPodListing);
         }
     }
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When operating in Kubernetes mode, if the JobManager undergoes a restart, it attempts to establish a connection with the API server to retrieve the complete list of TaskManager Pods, facilitating the recovery of previous TaskManagers.

In the context of a large Kubernetes cluster with potentially thousands of concurrently running jobs, a scenario may arise where all JobManagers undergo a restart and subsequently connect to the API server (e.g., during disaster recovery). This influx of requests may overwhelm the API server, reaching its maximum capacity and leading to the refusal of some JobManager requests. Consequently, certain JobManagers may experience failures and initiate reconnection attempts to the API server.

To enhance this process, we can propose the implementation of a retry mechanism. In the event of a failed connection attempt to the API server, Flink will introduce a waiting period before making subsequent connection attempts, mitigating the risk of overwhelming the server and improving the overall resilience of the system.

## Brief change log

- JM will try querying pods of the previous attempt from the Kubernetes API server when it restarts. 
- When the KubernetesResourceManagerDriver reaches the max attempt, it will throw a runtime Exception then the Flink cluster will shutdown.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
